### PR TITLE
Поиск пересечения полигональных моделей

### DIFF
--- a/code/src/boolean_poly/main.cpp
+++ b/code/src/boolean_poly/main.cpp
@@ -1,140 +1,140 @@
-#include <vector>
+#include <vector> 
 
-#include "common/PolyModel.h"
-#include "common/Point.h"
-#include "common/Triangle.h"
+#include "common/PolyModel.h" 
+#include "common/Point.h" 
+#include "common/Triangle.h" 
 
 using namespace std;
 using namespace rk9;
 
-// Поиск пересечения двух многогранников
-// model_a, model_b - исходные модели
-// Возвращает координаты точек, образующих контур пересечения
+// Поиск пересечения двух многогранников 
+// model_a, model_b - исходные модели 
+// Возвращает координаты точек, образующих контур пересечения 
 vector<Point> GetIntersectionPoints(PolyModel model_a, PolyModel model_b);
-
-void IntersectTriangles(Triangle tr1, Triangle tr2, vector<Point>& );
-void IntersectEdgeTriangle(Point, Point, Triangle tr, vector<Point>& );
-
-bool IsPlaneBetweenTriangle(Triangle tr1 , Triangle tr2 );
+bool IsTheSamePoints(Point p1, Point p2);
+void IntersectTriangles(Triangle tr1, Triangle tr2, vector<Point>& intersection_points);
+void IntersectEdgeTriangle(Point, Point, Triangle tr1,Triangle tr2, vector<Point>& intersection_points);
+bool IsPlaneBetweenTriangle(Triangle tr1, Triangle tr2);
+void DeleteSamePoints(vector<Point>& intersection_points);
 
 
 const double EPSILON = 1E-10;
 
 int main(int argc, char ** argv) {
 
-	PolyModel model_a, model_b,modelc,modeld;
+	PolyModel model_a, model_b;
 
-	/*Point p1, p2, p3,p4,p5,p6; 
-	p1.X = 0; p1.Y = 0; p1.Z = 0;
-	p2.X = 5; p2.Y = 0; p2.Z = 0;
-	p3.X = 2.5; p3.Y = 5; p3.Z = 0;
-	p4.X = 5; p4.Y = 1; p4.Z = 1;
-	p5.X = 2.5; p5.Y = 1; p5.Z = -3;
-	p6.X = 0; p6.Y = 1; p6.Z = -3;
-	model_a.AddTriangle(p1, p2, p3);
+	model_a.ReadFromSTLFile(argv[1]); 
+	model_b.ReadFromSTLFile(argv[2]); 
 	
-	model_b.AddTriangle(p4, p5, p6);*/
+	vector<Point> intersection_points = GetIntersectionPoints(model_a, model_b);
+	DeleteSamePoints(intersection_points);
 
-	model_a.ReadFromSTLFile(argv[1]);
-	model_b.ReadFromSTLFile(argv[2]);
+	//Из-за того, что модель состоит из треугольников, а в результате пересечения 
+	//мы получаем массив с количеством точек, не обязательно кратным 3, приходится 
+	//дублировать 1 или 2 точки, чтобы записать этот массив в STL-модель и отобразить рез-т
+	intersection_points.push_back(intersection_points[4]);
+	PolyModel modelz;
+	for (int i = 0; i < intersection_points.size() - 2; i += 3)
+		modelz.AddTriangle(intersection_points[i], intersection_points[i + 1], intersection_points[i+2] );
+	
+	modelz.WriteToSTLFile(argv[3]);
 
-
-	vector<Point> intersection_points= GetIntersectionPoints(model_a, model_b);
-	for(unsigned i;i<intersection_points.size();i++)
 	return 0;
 }
 
 vector<Point> GetIntersectionPoints(PolyModel model_a, PolyModel model_b) {
-
 	vector<Point> points;
 
 	unsigned triangles_count_A = model_a.GetTrianglesCount();
 	unsigned triangles_count_B = model_b.GetTrianglesCount();
 
 	for (unsigned i = 0; i < triangles_count_A; i++) {
-
 		Triangle tr1 = model_a.GetTriangleVertices(i);
-		for (unsigned j = 0; j < triangles_count_B; j++) {
 
+		for (unsigned j = 0; j < triangles_count_B; j++) {
 			Triangle tr2 = model_b.GetTriangleVertices(j);
-			if (IsPlaneBetweenTriangle(tr1, tr2) != true) {
-				//points of intersection of 2 triangles
-				IntersectTriangles(tr1, tr2, points);
+
+			if (IsPlaneBetweenTriangle(tr1, tr2) != true) {			
+				IntersectTriangles(tr1, tr2, points);//points of intersection of 2 triangles 
 			}
 		}
-		
 	}
 	return points;
 }
 
-
+//finding the intersection between the edge of one triangle and plane of another
 void IntersectTriangles(Triangle tr1, Triangle tr2, vector<Point> &points) {
-
-		IntersectEdgeTriangle(tr1.A, tr1.B, tr2,  points);  //finding the intersection between the edge of 
-		IntersectEdgeTriangle(tr1.A, tr1.C, tr2,  points);  //one triangle and plane of another
-		IntersectEdgeTriangle(tr1.B, tr1.C, tr2,  points);
-												
-		IntersectEdgeTriangle(tr2.A, tr2.B, tr1,  points);
-		IntersectEdgeTriangle(tr2.A, tr2.C, tr1,  points);
-		IntersectEdgeTriangle(tr2.B, tr2.C, tr1,  points);
-	
+	IntersectEdgeTriangle(tr1.A, tr1.B, tr2,tr1, points); 
+	IntersectEdgeTriangle(tr1.A, tr1.C, tr2,tr1, points);  
+	IntersectEdgeTriangle(tr1.B, tr1.C, tr2,tr1, points);
+											
+	IntersectEdgeTriangle(tr2.A, tr2.B, tr1,tr2, points);
+	IntersectEdgeTriangle(tr2.A, tr2.C, tr1,tr2, points);
+	IntersectEdgeTriangle(tr2.B, tr2.C, tr1,tr2, points);
 }
 
-void IntersectEdgeTriangle(Point point1, Point point2, Triangle tr, vector<Point> &points) {
 
-	Plane plane = tr.GetPlane();
-	/*double p1 = point2.X - point1.X;
-	double p2 = point2.Y - point1.Y;
-	double p3 = point2.Z - point1.Z;
-	if ((plane.A * p1 + plane.B * p2 + plane.C * p3) != 0) {   //if A*p1+B*p2+C*p3=0 so line lies in plane or paralells it
-
-		double t0 = (-plane.D - plane.C * point1.Z - plane.B * point1.Y - plane.A * point1.X) /
-			(plane.A * p1 + plane.B * p2 + plane.C * p3);
-
-		double X0 = p1*t0 + point1.X;
-		double Y0 = p2*t0 + point1.Y;
-		double Z0 = p3*t0 + point1.Z;*/
-
-			//pp.X = X0;
-			//pp.Y = Y0;
-			//pp.Z = Z0;
-	Point pp;
-	if (plane.GetIntersectionWithLine(point1, point2, pp) && !false)
+void IntersectEdgeTriangle(Point point1, Point point2, Triangle tr1,Triangle tr2, vector<Point> &points) {
+	Plane plane = tr1.GetPlane();
+	Point intersect_point;
+	if (plane.GetIntersectionWithLine(point1, point2, intersect_point))
 	{
-		if (tr.IsPointInsideTriangle(pp)) // check if finded point lies in triangle 
+		if ((tr1.IsPointInsideTriangle(intersect_point) ==true)&&// check if finded point lies in triangles
+			(tr2.IsPointInsideTriangle(intersect_point) == true))  
 		{
-			points.push_back(pp);
+			points.push_back(intersect_point);
 		}
 	}
-
-	
 }
 
-
-//check if there may be plane between triangles(all points of tr1 are on the one side of points of tr2)
+//check if there may be plane between triangles(all points of tr1 are on the one side of points of tr2) 
 bool IsPlaneBetweenTriangle(Triangle tr1, Triangle tr2) {
-	
-	if ((tr1.A.X < tr2.A.X && tr1.A.Y < tr2.A.Y && tr1.A.Z < tr2.A.Z&&
-		 tr1.A.X < tr2.B.X && tr1.A.Y < tr2.B.Y && tr1.A.Z < tr2.B.Z&&
-		 tr1.A.X < tr2.C.X && tr1.A.Y < tr2.C.Y && tr1.A.Z < tr2.C.Z&&
-		 tr1.B.X < tr2.A.X && tr1.B.Y < tr2.A.Y && tr1.B.Z < tr2.A.Z&&
-		 tr1.B.X < tr2.B.X && tr1.B.Y < tr2.B.Y && tr1.B.Z < tr2.B.Z&&
-		 tr1.B.X < tr2.C.X && tr1.B.Y < tr2.C.Y && tr1.B.Z < tr2.C.Z&&
-		 tr1.C.X < tr2.A.X && tr1.C.Y < tr2.A.Y && tr1.C.Z < tr2.A.Z&&
-		 tr1.C.X < tr2.B.X && tr1.C.Y < tr2.B.Y && tr1.C.Z < tr2.B.Z&&
-		 tr1.C.X < tr2.C.X && tr1.C.Y < tr2.C.Y && tr1.C.Z < tr2.C.Z)
-		 ||
-		(tr1.A.X > tr2.A.X && tr1.A.Y > tr2.A.Y && tr1.A.Z > tr2.A.Z&&
-		 tr1.A.X > tr2.B.X && tr1.A.Y > tr2.B.Y && tr1.A.Z > tr2.B.Z&&
-		 tr1.A.X > tr2.C.X && tr1.A.Y > tr2.C.Y && tr1.A.Z > tr2.C.Z&&
-		 tr1.B.X > tr2.A.X && tr1.B.Y > tr2.A.Y && tr1.B.Z > tr2.A.Z&&
-		 tr1.B.X > tr2.B.X && tr1.B.Y > tr2.B.Y && tr1.B.Z > tr2.B.Z&&
-		 tr1.B.X > tr2.C.X && tr1.B.Y > tr2.C.Y && tr1.B.Z > tr2.C.Z&&
-		 tr1.C.X > tr2.A.X && tr1.C.Y > tr2.A.Y && tr1.C.Z > tr2.A.Z&&
-		 tr1.C.X > tr2.B.X && tr1.C.Y > tr2.B.Y && tr1.C.Z > tr2.B.Z&&
-		 tr1.C.X > tr2.C.X && tr1.C.Y > tr2.C.Y && tr1.C.Z > tr2.C.Z))
-
-		return true;
+	if (((tr1.A.X <tr2.A.X) &&( tr1.A.Y < tr2.A.Y) &&( tr1.A.Z<tr2.A.Z)&& 
+		 (tr1.A.X <tr2.B.X) &&( tr1.A.Y < tr2.B.Y) &&( tr1.A.Z<tr2.B.Z)&& 
+		 (tr1.A.X <tr2.C.X) &&( tr1.A.Y < tr2.C.Y) &&( tr1.A.Z<tr2.C.Z)&& 
+		 (tr1.B.X <tr2.A.X) &&( tr1.B.Y < tr2.A.Y) &&( tr1.B.Z<tr2.A.Z)&& 
+		 (tr1.B.X <tr2.B.X) &&( tr1.B.Y < tr2.B.Y) &&( tr1.B.Z<tr2.B.Z)&& 
+		 (tr1.B.X <tr2.C.X) &&( tr1.B.Y < tr2.C.Y) &&( tr1.B.Z<tr2.C.Z)&& 
+		 (tr1.C.X <tr2.A.X) &&( tr1.C.Y < tr2.A.Y) &&( tr1.C.Z<tr2.A.Z)&& 
+		 (tr1.C.X <tr2.B.X) &&( tr1.C.Y < tr2.B.Y) &&( tr1.C.Z<tr2.B.Z)&& 
+		 (tr1.C.X <tr2.C.X) &&( tr1.C.Y < tr2.C.Y) &&( tr1.C.Z<tr2.C.Z))
+		||		 	
+		((tr1.A.X > tr2.A.X)&& (tr1.A.Y > tr2.A.Y )&& (tr1.A.Z > tr2.A.Z)&&
+		 (tr1.A.X > tr2.B.X)&& (tr1.A.Y > tr2.B.Y )&& (tr1.A.Z > tr2.B.Z)&&
+		 (tr1.A.X > tr2.C.X)&& (tr1.A.Y > tr2.C.Y )&& (tr1.A.Z > tr2.C.Z)&&
+		 (tr1.B.X > tr2.A.X)&& (tr1.B.Y > tr2.A.Y )&& (tr1.B.Z > tr2.A.Z)&&
+		 (tr1.B.X > tr2.B.X)&& (tr1.B.Y > tr2.B.Y )&& (tr1.B.Z > tr2.B.Z)&&
+		 (tr1.B.X > tr2.C.X)&& (tr1.B.Y > tr2.C.Y )&& (tr1.B.Z > tr2.C.Z)&&
+		 (tr1.C.X > tr2.A.X)&& (tr1.C.Y > tr2.A.Y )&& (tr1.C.Z > tr2.A.Z)&&
+		 (tr1.C.X > tr2.B.X)&& (tr1.C.Y > tr2.B.Y )&& (tr1.C.Z > tr2.B.Z)&&
+		 (tr1.C.X > tr2.C.X)&& (tr1.C.Y > tr2.C.Y )&& (tr1.C.Z > tr2.C.Z)))
+		 return true;
+	else return false;
 
 }
 
+//Check if points are the same
+bool IsTheSamePoints(Point p1, Point p2)
+{
+	if ((p1.X == p2.X) && (p1.Y == p2.Y) && (p2.Z == p1.Z))
+	{
+		return true;
+	}
+	else return false;
+}
+
+//delete same points in array of intersection points
+void DeleteSamePoints(vector<Point>& points)
+{
+	for (int i = 0; i<points.size() - 1; i++) {
+		for (int j = i + 1; j < points.size(); j++)
+		{
+			if ((IsTheSamePoints(points[i], points[j])) == true)
+			{
+				points.erase(points.begin() + j);
+				j--;
+			}
+		}
+	}
+}

--- a/code/src/boolean_poly/main.cpp
+++ b/code/src/boolean_poly/main.cpp
@@ -12,20 +12,35 @@ using namespace rk9;
 // Возвращает координаты точек, образующих контур пересечения
 vector<Point> GetIntersectionPoints(PolyModel model_a, PolyModel model_b);
 
-void IntersectTriangles(vector<Point> *, vector<Point> *, vector<Point> *);
-void IntersectEdgeTriangle(Point, Point, vector<Point> *, double *, vector<Point> *);
+void IntersectTriangles(Triangle tr1, Triangle tr2, vector<Point>& );
+void IntersectEdgeTriangle(Point, Point, Triangle tr, vector<Point>& );
 
-bool IsPlaneBetweenTriangle(vector<Point> *, vector<Point> *);
+bool IsPlaneBetweenTriangle(Triangle tr1 , Triangle tr2 );
 
 
 const double EPSILON = 1E-10;
 
 int main(int argc, char ** argv) {
 
-	PolyModel model_a, model_b;
+	PolyModel model_a, model_b,modelc,modeld;
 
-	vector<Point> intersection_points = GetIntersectionPoints(model_a, model_b);
+	/*Point p1, p2, p3,p4,p5,p6; 
+	p1.X = 0; p1.Y = 0; p1.Z = 0;
+	p2.X = 5; p2.Y = 0; p2.Z = 0;
+	p3.X = 2.5; p3.Y = 5; p3.Z = 0;
+	p4.X = 5; p4.Y = 1; p4.Z = 1;
+	p5.X = 2.5; p5.Y = 1; p5.Z = -3;
+	p6.X = 0; p6.Y = 1; p6.Z = -3;
+	model_a.AddTriangle(p1, p2, p3);
+	
+	model_b.AddTriangle(p4, p5, p6);*/
 
+	model_a.ReadFromSTLFile(argv[1]);
+	model_b.ReadFromSTLFile(argv[2]);
+
+
+	vector<Point> intersection_points= GetIntersectionPoints(model_a, model_b);
+	for(unsigned i;i<intersection_points.size();i++)
 	return 0;
 }
 
@@ -38,90 +53,88 @@ vector<Point> GetIntersectionPoints(PolyModel model_a, PolyModel model_b) {
 
 	for (unsigned i = 0; i < triangles_count_A; i++) {
 
-		vector<Point> points_of_triangle_i = model_a.GetTriangleVertices(i);
+		Triangle tr1 = model_a.GetTriangleVertices(i);
 		for (unsigned j = 0; j < triangles_count_B; j++) {
 
-			vector<Point> points_of_triangle_j = model_b.GetTriangleVertices(j);
-			
-			//points of intersection of 2 triangles
-			//IntersectTriangles(points_of_triangle_i, points_of_triangle_j, points); 
+			Triangle tr2 = model_b.GetTriangleVertices(j);
+			if (IsPlaneBetweenTriangle(tr1, tr2) != true) {
+				//points of intersection of 2 triangles
+				IntersectTriangles(tr1, tr2, points);
+			}
 		}
+		
 	}
 	return points;
 }
 
-/*
-void IntersectTriangles(vector<Point> points_of_triangle_i, vector<Point> points_of_triangle_j, vector<Point> points) {
 
-	if (IsPlaneBetweenTriangle(points_of_triangle_i, points_of_triangle_j) == false) {
+void IntersectTriangles(Triangle tr1, Triangle tr2, vector<Point> &points) {
 
-		double *normal = GetTriangleNormal(points_of_triangle_j); //find parameters A,B,C,D of normal
-
-		IntersectEdgeTriangle(points_of_triangle_i.at(0), points_of_triangle_i.at(1), points_of_triangle_j, normal, points);  //finding the intersection between the edge of 
-		IntersectEdgeTriangle(points_of_triangle_i.at(0), points_of_triangle_i.at(2), points_of_triangle_j, normal, points);  //one triangle and plane of another
-		IntersectEdgeTriangle(points_of_triangle_i.at(1), points_of_triangle_i.at(2), points_of_triangle_j, normal, points);
-
-		normal = GetTriangleNormal(points_of_triangle_i);
-
-		IntersectEdgeTriangle(points_of_triangle_j.at(0), points_of_triangle_j.at(1), points_of_triangle_i, normal, points);
-		IntersectEdgeTriangle(points_of_triangle_j.at(0), points_of_triangle_j.at(2), points_of_triangle_i, normal, points);
-		IntersectEdgeTriangle(points_of_triangle_j.at(1), points_of_triangle_j.at(2), points_of_triangle_i, normal, points);
-	}
-
+		IntersectEdgeTriangle(tr1.A, tr1.B, tr2,  points);  //finding the intersection between the edge of 
+		IntersectEdgeTriangle(tr1.A, tr1.C, tr2,  points);  //one triangle and plane of another
+		IntersectEdgeTriangle(tr1.B, tr1.C, tr2,  points);
+												
+		IntersectEdgeTriangle(tr2.A, tr2.B, tr1,  points);
+		IntersectEdgeTriangle(tr2.A, tr2.C, tr1,  points);
+		IntersectEdgeTriangle(tr2.B, tr2.C, tr1,  points);
+	
 }
 
-void IntersectEdgeTriangle(Point point1, Point point2, vector<Point> *points_of_triangle_j, double *normal, vector<Point> *points) {
+void IntersectEdgeTriangle(Point point1, Point point2, Triangle tr, vector<Point> &points) {
 
-	double p1 = point2.X - point1.X;
+	Plane plane = tr.GetPlane();
+	/*double p1 = point2.X - point1.X;
 	double p2 = point2.Y - point1.Y;
 	double p3 = point2.Z - point1.Z;
-	if ((normal[0] * p1 + normal[1] * p2 + normal[2] * p3) != 0) {   //if A*p1+B*p2+C*p3=0 so line lies in plane or paralells it
+	if ((plane.A * p1 + plane.B * p2 + plane.C * p3) != 0) {   //if A*p1+B*p2+C*p3=0 so line lies in plane or paralells it
 
-		double t0 = (-normal[3] - normal[2] * point1.Z - normal[1] * point1.Y - normal[0] * point1.X) /
-			(normal[0] * p1 + normal[1] * p2 + normal[2] * p3);
+		double t0 = (-plane.D - plane.C * point1.Z - plane.B * point1.Y - plane.A * point1.X) /
+			(plane.A * p1 + plane.B * p2 + plane.C * p3);
 
 		double X0 = p1*t0 + point1.X;
 		double Y0 = p2*t0 + point1.Y;
-		double Z0 = p3*t0 + point1.Z;
+		double Z0 = p3*t0 + point1.Z;*/
 
-		Point pp;
-		pp.X = X0;
-		pp.Y = Y0;
-		pp.Z = Z0;
-
-		if (IsPointInsideTriangle(pp, points_of_triangle_j)) // check if finded point lies in triangle 
+			//pp.X = X0;
+			//pp.Y = Y0;
+			//pp.Z = Z0;
+	Point pp;
+	if (plane.GetIntersectionWithLine(point1, point2, pp) && !false)
+	{
+		if (tr.IsPointInsideTriangle(pp)) // check if finded point lies in triangle 
 		{
-			points->push_back(pp);
+			points.push_back(pp);
 		}
-
 	}
+
+	
 }
 
-//check if there may be plane between triangles(all points of tr1 are on the one side of points of tr2)
-bool IsPlaneBetweenTriangle(vector<Point> *tr1, vector<Point> *tr2) {
 
-	if ((tr1->at(0).X < tr2->at(0).X && tr1->at(0).Y < tr2->at(0).Y && tr1->at(0).Z < tr2->at(0).Z&&
-		 tr1->at(0).X < tr2->at(1).X && tr1->at(0).Y < tr2->at(1).Y && tr1->at(0).Z < tr2->at(1).Z&&
-		 tr1->at(0).X < tr2->at(2).X && tr1->at(0).Y < tr2->at(2).Y && tr1->at(0).Z < tr2->at(2).Z&&
-		 tr1->at(1).X < tr2->at(0).X && tr1->at(1).Y < tr2->at(0).Y && tr1->at(1).Z < tr2->at(0).Z&&
-		 tr1->at(1).X < tr2->at(1).X && tr1->at(1).Y < tr2->at(1).Y && tr1->at(1).Z < tr2->at(1).Z&&
-		 tr1->at(1).X < tr2->at(2).X && tr1->at(1).Y < tr2->at(2).Y && tr1->at(1).Z < tr2->at(2).Z&&
-		 tr1->at(2).X < tr2->at(0).X && tr1->at(2).Y < tr2->at(0).Y && tr1->at(2).Z < tr2->at(0).Z&&
-		 tr1->at(2).X < tr2->at(1).X && tr1->at(2).Y < tr2->at(1).Y && tr1->at(2).Z < tr2->at(1).Z&&
-		 tr1->at(2).X < tr2->at(2).X && tr1->at(2).Y < tr2->at(2).Y && tr1->at(2).Z < tr2->at(2).Z)
+//check if there may be plane between triangles(all points of tr1 are on the one side of points of tr2)
+bool IsPlaneBetweenTriangle(Triangle tr1, Triangle tr2) {
+	
+	if ((tr1.A.X < tr2.A.X && tr1.A.Y < tr2.A.Y && tr1.A.Z < tr2.A.Z&&
+		 tr1.A.X < tr2.B.X && tr1.A.Y < tr2.B.Y && tr1.A.Z < tr2.B.Z&&
+		 tr1.A.X < tr2.C.X && tr1.A.Y < tr2.C.Y && tr1.A.Z < tr2.C.Z&&
+		 tr1.B.X < tr2.A.X && tr1.B.Y < tr2.A.Y && tr1.B.Z < tr2.A.Z&&
+		 tr1.B.X < tr2.B.X && tr1.B.Y < tr2.B.Y && tr1.B.Z < tr2.B.Z&&
+		 tr1.B.X < tr2.C.X && tr1.B.Y < tr2.C.Y && tr1.B.Z < tr2.C.Z&&
+		 tr1.C.X < tr2.A.X && tr1.C.Y < tr2.A.Y && tr1.C.Z < tr2.A.Z&&
+		 tr1.C.X < tr2.B.X && tr1.C.Y < tr2.B.Y && tr1.C.Z < tr2.B.Z&&
+		 tr1.C.X < tr2.C.X && tr1.C.Y < tr2.C.Y && tr1.C.Z < tr2.C.Z)
 		 ||
-		(tr1->at(0).X > tr2->at(0).X && tr1->at(0).Y > tr2->at(0).Y && tr1->at(0).Z > tr2->at(0).Z&&
-		 tr1->at(0).X > tr2->at(1).X && tr1->at(0).Y > tr2->at(1).Y && tr1->at(0).Z > tr2->at(1).Z&&
-		 tr1->at(0).X > tr2->at(2).X && tr1->at(0).Y > tr2->at(2).Y && tr1->at(0).Z > tr2->at(2).Z&&
-		 tr1->at(1).X > tr2->at(0).X && tr1->at(1).Y > tr2->at(0).Y && tr1->at(1).Z > tr2->at(0).Z&&
-		 tr1->at(1).X > tr2->at(1).X && tr1->at(1).Y > tr2->at(1).Y && tr1->at(1).Z > tr2->at(1).Z&&
-		 tr1->at(1).X > tr2->at(2).X && tr1->at(1).Y > tr2->at(2).Y && tr1->at(1).Z > tr2->at(2).Z&&
-		 tr1->at(2).X > tr2->at(0).X && tr1->at(2).Y > tr2->at(0).Y && tr1->at(2).Z > tr2->at(0).Z&&
-		 tr1->at(2).X > tr2->at(1).X && tr1->at(2).Y > tr2->at(1).Y && tr1->at(2).Z > tr2->at(1).Z&&
-		 tr1->at(2).X > tr2->at(2).X && tr1->at(2).Y > tr2->at(2).Y && tr1->at(2).Z > tr2->at(2).Z))
+		(tr1.A.X > tr2.A.X && tr1.A.Y > tr2.A.Y && tr1.A.Z > tr2.A.Z&&
+		 tr1.A.X > tr2.B.X && tr1.A.Y > tr2.B.Y && tr1.A.Z > tr2.B.Z&&
+		 tr1.A.X > tr2.C.X && tr1.A.Y > tr2.C.Y && tr1.A.Z > tr2.C.Z&&
+		 tr1.B.X > tr2.A.X && tr1.B.Y > tr2.A.Y && tr1.B.Z > tr2.A.Z&&
+		 tr1.B.X > tr2.B.X && tr1.B.Y > tr2.B.Y && tr1.B.Z > tr2.B.Z&&
+		 tr1.B.X > tr2.C.X && tr1.B.Y > tr2.C.Y && tr1.B.Z > tr2.C.Z&&
+		 tr1.C.X > tr2.A.X && tr1.C.Y > tr2.A.Y && tr1.C.Z > tr2.A.Z&&
+		 tr1.C.X > tr2.B.X && tr1.C.Y > tr2.B.Y && tr1.C.Z > tr2.B.Z&&
+		 tr1.C.X > tr2.C.X && tr1.C.Y > tr2.C.Y && tr1.C.Z > tr2.C.Z))
 
 		return true;
 
 }
 
-*/

--- a/code/src/common/include/common/PolyModel.h
+++ b/code/src/common/include/common/PolyModel.h
@@ -21,7 +21,7 @@ namespace rk9
 		void AddTriangle(Point p1, Point p2, Point p3);
 		unsigned GetTrianglesCount();
 
-		std::vector<Point> GetTriangleVertices(unsigned index);
+		Triangle GetTriangleVertices(unsigned index);
 
 	};
 }

--- a/code/src/common/include/common/PolyModel.h
+++ b/code/src/common/include/common/PolyModel.h
@@ -14,6 +14,7 @@ namespace rk9
 	
 		std::vector<Triangle> Triangles;
 
+
 	public:
 		int ReadFromSTLFile(char * filename);
 		int WriteToSTLFile(char * filename);
@@ -22,6 +23,6 @@ namespace rk9
 		unsigned GetTrianglesCount();
 
 		Triangle GetTriangleVertices(unsigned index);
-
+		std::vector<Point>Points;
 	};
 }

--- a/code/src/common/src/PolyModel.cpp
+++ b/code/src/common/src/PolyModel.cpp
@@ -86,20 +86,20 @@ namespace rk9
 			// Запишем координаты треугольника
 			float coordinates[9];
 			Triangle tr = Triangles[i];
-
-			vector<Point> pts = GetTriangleVertices(i);
-
-			coordinates[0] = static_cast<float>(pts[0].X);
-			coordinates[1] = static_cast<float>(pts[0].Y);
-			coordinates[2] = static_cast<float>(pts[0].Z);
+			
+			
+			
+			coordinates[0] = static_cast<float>(tr.A.X);
+			coordinates[1] = static_cast<float>(tr.A.Y);
+			coordinates[2] = static_cast<float>(tr.A.Z);
 						   	 
-			coordinates[3] = static_cast<float>(pts[1].X);
-			coordinates[4] = static_cast<float>(pts[1].Y);
-			coordinates[5] = static_cast<float>(pts[1].Z);
+			coordinates[3] = static_cast<float>(tr.B.X);
+			coordinates[4] = static_cast<float>(tr.B.Y);
+			coordinates[5] = static_cast<float>(tr.B.Z);
 						   	 						 
-			coordinates[6] = static_cast<float>(pts[2].X);
-			coordinates[7] = static_cast<float>(pts[2].Y);
-			coordinates[8] = static_cast<float>(pts[2].Z);
+			coordinates[6] = static_cast<float>(tr.C.X);
+			coordinates[7] = static_cast<float>(tr.C.Y);
+			coordinates[8] = static_cast<float>(tr.C.Z);
 
 			fout.write(reinterpret_cast<char *>(coordinates), 9 * sizeof(float));
 
@@ -125,14 +125,11 @@ namespace rk9
 
 	// Возвращает массив вершин треугольника под индексом index
 	// Если треугольника с таким индексом нет, возвращает пустой массив
-	vector<Point> PolyModel::GetTriangleVertices(unsigned index) {
-		vector<Point> points;
-		if (index <= GetTrianglesCount()) {
-			points.push_back(Triangles[index].Verts[0]);
-			points.push_back(Triangles[index].Verts[1]);
-			points.push_back(Triangles[index].Verts[2]);
-		}
-		return points;
+	Triangle PolyModel::GetTriangleVertices(unsigned index) {
+		
+		if (index <= GetTrianglesCount()) 
+			return Triangles[index];
+		
 	}
 	
 }

--- a/code/src/common/src/PolyModel.cpp
+++ b/code/src/common/src/PolyModel.cpp
@@ -117,7 +117,7 @@ namespace rk9
 		Triangle t{ p1, p2, p3 };
 		Triangles.push_back(t);
 	}
-
+	
 	//return the number of triangles in polymodel
 	unsigned PolyModel::GetTrianglesCount() {
 		return Triangles.size();
@@ -131,5 +131,6 @@ namespace rk9
 			return Triangles[index];
 		
 	}
-	
+
 }
+


### PR DESCRIPTION
Протестировал на нескольких моделях, в том числе: кубы, цилиндры, торы. Все точки пересечения находит верно. Большой минус - быстродействие. Фигуры 9000х400 треугольников вызывают, соответственно, 3600000 вызовов функции на поиск пересечения ребра с плоскостью - это все и замедляет. Надо вводить условия и ограничения на тесты, чтобы улучшить быстродействие-над этим пока работаю. Выкладываю промежуточный рабочий вариант.
